### PR TITLE
update dev-requirements to address vulnerabilities in urllib3

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
 flake8
 pytest
-scipy==1.0.0
-scikit-learn==0.19.1
+scipy>=1.0.0
+scikit-learn>=0.19.1


### PR DESCRIPTION
This UNTESTED patch updates dev-requirements to remove version pinning on dependencies. Downstream dependencies require urllib3 which have the following two HIGH severity vulnerabilities. 
- CVE-2018-20060
- CVE-2019-11324

How do I tell if this code is deployed?

--timball